### PR TITLE
If a variable name is passed to the get_metadata templatetag, it shou…

### DIFF
--- a/djangoseo/templatetags/seo.py
+++ b/djangoseo/templatetags/seo.py
@@ -68,7 +68,7 @@ class MetadataNode(template.Node):
 
         # If a variable name is given, store the result there
         if self.variable_name is not None:
-            context.dicts[0][self.variable_name] = metadata
+            context.dicts[-1][self.variable_name] = metadata
             return ''
         else:
             return text_type(metadata)


### PR DESCRIPTION
…ld pop the value into the top-most context dict instead of the bottom-most context dict.

This is a bug with the current implementation. Let's say I have the following in my template code:

```
{% get_metadata as meta %}
```

it will add `meta` into the bottom-most context dict, so if there's another context dict on top with a variable `meta`, it will override the value here and my meta information won't be displayed (or even worse, it'll display wrong/gibberish information). 

You can avoid this scenario by choosing a unique variable name here, but I think this bug should be fixed at the source. 