### PR TITLE
Change language_code max_length to 7

### DIFF
--- a/djangoseo/backends.py
+++ b/djangoseo/backends.py
@@ -206,7 +206,7 @@ class PathBackend(MetadataBackend):
             if options.use_i18n:
                 _language = models.CharField(
                     _("language"),
-                    max_length=5,
+                    max_length=7,
                     null=True,
                     blank=True,
                     db_index=True,
@@ -438,7 +438,7 @@ class ModelBackend(MetadataBackend):
             if options.use_i18n:
                 _language = models.CharField(
                     _("language"),
-                    max_length=5,
+                    max_length=7,
                     null=True,
                     blank=True,
                     db_index=True,

--- a/djangoseo/backends.py
+++ b/djangoseo/backends.py
@@ -273,7 +273,7 @@ class ViewBackend(MetadataBackend):
             if options.use_i18n:
                 _language = models.CharField(
                     _("language"),
-                    max_length=5,
+                    max_length=7,
                     null=True,
                     blank=True,
                     db_index=True,
@@ -347,7 +347,7 @@ class ModelInstanceBackend(MetadataBackend):
             if options.use_i18n:
                 _language = models.CharField(
                     _("language"),
-                    max_length=5,
+                    max_length=7,
                     null=True,
                     blank=True,
                     db_index=True,


### PR DESCRIPTION
From Django 1.9 the language_code would support [ISO15924](http://www.unicode.org/iso15924/codelists.html), and the max_length should be extended to 7: `{2 letters language code}-{4 letters country code}`
